### PR TITLE
Joel/nav 7897 tags subscribers v4 update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.1)
+    convertkit-api-ruby (0.0.2)
       faraday (>= 1.0, < 3.0)
 
 GEM
@@ -9,9 +9,10 @@ GEM
   specs:
     diff-lcs (1.5.0)
     docile (1.4.0)
-    faraday (1.0.0)
-      multipart-post (>= 1.2, < 3)
-    multipart-post (2.3.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -25,6 +26,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
+    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/convertkit/resources/subscribers.rb
+++ b/lib/convertkit/resources/subscribers.rb
@@ -32,8 +32,24 @@ module ConvertKit
         SubscriberResponse.new(response)
       end
 
+      # Create a new subscriber
+      # See https://developers.convertkit.com/v4_alpha.html#post__alpha_subscribers
+      # @param [String] email Subscriber's email address
+      # @param [Hash] options
+      # @option options [String] :first_name Subscriber's first name
+      def create(email, options = {})
+        request_options = {
+          email_address: email,
+          first_name: options[:first_name],
+        }.compact
+
+        response = @client.post(PATH, request_options)
+
+        SubscriberResponse.new(response['subscriber'])
+      end
+
       # Update the information of a subscriber
-      # See https://developers.convertkit.com/#update-subscriber for details
+      # See https://developers.convertkit.com/v4_alpha.html?shell#put_alpha_subscribers-id for details
       # @param [Integer] subscriber_id
       # @param [Hash] options
       # @option options [String] :first_name Subscriber's first name
@@ -42,7 +58,7 @@ module ConvertKit
       def update(subscriber_id, options = {})
         request_options = options.slice(:first_name, :email_address, :fields)
         response = @client.put("#{PATH}/#{subscriber_id}", request_options)
-        SubscriberResponse.new(response)
+        SubscriberResponse.new(response['subscriber'])
       end
 
       # Unsubscribe an email address from all forms and sequences

--- a/lib/convertkit/resources/tags.rb
+++ b/lib/convertkit/resources/tags.rb
@@ -18,21 +18,12 @@ module ConvertKit
       end
 
       # Creates a new tag for the account.
-      # See https://developers.convertkit.com/#create-a-tag for details
-      # @param [String, Array<String>] name
+      # See https://developers.convertkit.com/v4_alpha.html#post__alpha_tags for details
+      # @param [String] name
       def create(name)
-        is_array = name.is_a? Array
-        request = is_array ? name.map { |n| { name: n } } : { name: name }
+        response = @client.post(PATH, { name: name })
 
-        response = @client.post(PATH, {tag: request})
-
-        if is_array
-          response.map do |tag|
-            TagResponse.new(tag)
-          end
-        else
-          TagResponse.new(response)
-        end
+        TagResponse.new(response)
       end
 
       # Tags a subscriber with the given email address.

--- a/lib/convertkit/utils.rb
+++ b/lib/convertkit/utils.rb
@@ -4,7 +4,7 @@ module ConvertKit
       def to_datetime(value)
         return nil if !value.is_a?(String) || value.strip.empty?
 
-        DateTime.iso8601(value)
+        DateTime.parse(value)
       end
     end
   end

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/lib/convertkit/resources/subscribers_spec.rb
+++ b/spec/lib/convertkit/resources/subscribers_spec.rb
@@ -62,21 +62,59 @@ describe ConvertKit::Resources::Subscribers do
     end
   end
 
+  describe '#create' do
+    let(:subscribers) { ConvertKit::Resources::Subscribers.new(client) }
+
+    it 'creates a subscriber with just an email' do
+      response = {
+        'subscriber' => {
+          'id' => 1,
+          'first_name' => nil,
+          'email_address' => 'test@test.com',
+          'state' => 'active',
+          'fields' => {},
+        }
+      }
+
+      expect(client).to receive(:post).with('subscribers', { email_address: 'test@test.com' }).and_return(response)
+      subscriber_response = subscribers.create('test@test.com')
+      validate_subscriber(subscriber_response, response['subscriber'])
+    end
+
+    it 'creates a subscriber with an email and first name' do
+      response = {
+        'subscriber' => {
+          'id' => 1,
+          'first_name' => 'test first name',
+          'email_address' => 'test@test.com',
+          'state' => 'active',
+          'fields' => {},
+        }
+      }
+
+      expect(client).to receive(:post).with('subscribers', { email_address: 'test@test.com', first_name: 'test first name' }).and_return(response)
+      subscriber_response = subscribers.create('test@test.com', { first_name: 'test first name' })
+      validate_subscriber(subscriber_response, response['subscriber'])
+    end
+  end
+
   describe '#update' do
     let(:subscribers) { ConvertKit::Resources::Subscribers.new(client) }
 
     it 'updates a subscriber' do
       response = {
-        'id' => 1,
-        'first_name' => 'updated_first_name',
-        'email_address' => 'test@test.com',
-        'state' => 'active',
-        'created_at' => '2023-08-09T04:30:00Z',
-        'fields' => { 'last_name' => 'subscriber_last_name' }
+        'subscriber' => {
+          'id' => 1,
+          'first_name' => 'updated_first_name',
+          'email_address' => 'test@test.com',
+          'state' => 'active',
+          'created_at' => '2023-08-09T04:30:00Z',
+          'fields' => { 'last_name' => 'subscriber_last_name' }
+        }
       }
       expect(client).to receive(:put).with('subscribers/1', { first_name: 'updated_first_name' }).and_return(response)
       subscriber_response = subscribers.update(1, { first_name: 'updated_first_name' })
-      validate_subscriber(subscriber_response, response)
+      validate_subscriber(subscriber_response, response['subscriber'])
     end
   end
 

--- a/spec/lib/convertkit/resources/tags_spec.rb
+++ b/spec/lib/convertkit/resources/tags_spec.rb
@@ -32,21 +32,9 @@ describe ConvertKit::Resources::Tags do
     context 'when name is a string' do
       it 'creates a tag' do
         response = { 'id' => 1, 'name' => 'tag_name', account_id: 1, state: 'available', 'created_at' => '2023-08-09T04:30:00Z', updated_at: '2023-08-09T04:30:00Z'}
-        expect(client).to receive(:post).with('tags', {tag: {name: 'tag_name'}}).and_return(response)
+        expect(client).to receive(:post).with('tags', {name: 'tag_name'}).and_return(response)
         tags_response = tags.create('tag_name')
         validate_tag(tags_response, response)
-      end
-    end
-
-    context 'when name is an array' do
-      it 'creates tags' do
-        response = [
-          { 'id' => 1, 'name' => 'tag_name1', account_id: 1, state: 'available', 'created_at' => '2023-08-09T04:30:00Z', updated_at: '2023-08-09T04:30:00Z'},
-          { 'id' => 2, 'name' => 'tag_name2', account_id: 1, state: 'available', 'created_at' => '2023-08-10T04:30:00Z', updated_at: '2023-08-10T04:30:00Z'}
-        ]
-        expect(client).to receive(:post).with('tags', {tag: [{name: 'tag_name1'}, {name: 'tag_name2'}]}).and_return(response)
-        tags_response = tags.create(%w[tag_name1 tag_name2])
-        validate_tags(tags_response, response)
       end
     end
   end


### PR DESCRIPTION
Made updates to the subscriber endpoint, so that it will now support [creating a subscriber](https://developers.convertkit.com/v4_alpha.html?shell#put_alpha_subscribers-id). I've slightly adjusted the response for the update method as well to conform to the V4 response. Additionally I've updated the [create tag endpoint ](https://developers.convertkit.com/v4_alpha.html?shell#post__alpha_tags)to match the definition in the V4 API. 