### PR TITLE
Joel/nav 7981 fix client http method calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.4)
+    convertkit-api-ruby (0.0.5)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -48,15 +48,15 @@ module ConvertKit
 
     # Defined wrapper methods for ConvertKit Connection methods
     HTTP_METHODS.each do |method|
-      define_method(method) do |path, params = {}, raw_response: false|
+      define_method(method) do |path, params = {}, raw_response = false|
         response = @connection.public_send(method, path, params)
-        handle_response(response, raw_response: raw_response)
+        handle_response(response, raw_response)
       end
     end
 
     private
 
-    def handle_response(response, raw_response: false)
+    def handle_response(response, raw_response= false)
       if response.success?
         raw_response ? response: response.body
       else

--- a/lib/convertkit/resources/subscribers.rb
+++ b/lib/convertkit/resources/subscribers.rb
@@ -77,7 +77,7 @@ module ConvertKit
       # See https://developers.convertkit.com/v4_alpha.html#post_alpha_subscribers-id-_unsubscribe
       # @param [Integer] subscriber_id
       def unsubscribe(subscriber_id)
-        response = @client.post("#{PATH}/#{subscriber_id}/unsubscribe", '', raw_response: true)
+        response = @client.post("#{PATH}/#{subscriber_id}/unsubscribe", '', true)
 
         response.success?
       end

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/lib/convertkit/client_spec.rb
+++ b/spec/lib/convertkit/client_spec.rb
@@ -143,8 +143,8 @@ describe ConvertKit::Client do
     let(:response) { double('response', success?: true, body: 'test_body') }
 
     it 'calls the get method on the connection' do
-      expect(client.instance_variable_get(:@connection)).to receive(:post).with('test_path', {}).and_return(response)
-      expect(client.post('test_path')).to eq('test_body')
+      expect(client.instance_variable_get(:@connection)).to receive(:post).with('test_path', {some: 'parameter'}).and_return(response)
+      expect(client.post('test_path', some: 'parameter')).to eq('test_body')
     end
   end
 
@@ -163,8 +163,8 @@ describe ConvertKit::Client do
     let(:response) { double('response', success?: true, body: 'test_body') }
 
     it 'calls the get method on the connection' do
-      expect(client.instance_variable_get(:@connection)).to receive(:put).with('test_path', {}).and_return(response)
-      expect(client.put('test_path')).to eq('test_body')
+      expect(client.instance_variable_get(:@connection)).to receive(:put).with('test_path', {some: 'parameter'}).and_return(response)
+      expect(client.put('test_path', {some: 'parameter'})).to eq('test_body')
     end
   end
 
@@ -179,7 +179,7 @@ describe ConvertKit::Client do
       end
 
       it 'returns the raw response' do
-        expect(client.send(:handle_response, response, raw_response: true)).to eq(response)
+        expect(client.send(:handle_response, response, true)).to eq(response)
       end
     end
 

--- a/spec/lib/convertkit/resources/subscribers_spec.rb
+++ b/spec/lib/convertkit/resources/subscribers_spec.rb
@@ -167,7 +167,7 @@ describe ConvertKit::Resources::Subscribers do
     let(:response) { double('response', success?: true) }
 
     it 'unsubscribes a subscriber' do
-      expect(client).to receive(:post).with('subscribers/1/unsubscribe', "", raw_response: true).and_return(response)
+      expect(client).to receive(:post).with('subscribers/1/unsubscribe', "", true).and_return(response)
       expect(subscribers.unsubscribe(1)).to be(true)
     end
   end


### PR DESCRIPTION
Fixed a bug where HTTP method calls failed when passing a parameter. This was due to the addition of the optional parameter `raw_response` being a hash which conflated with the http parameters. 

All specs are passing
![CleanShot 2023-10-03 at 14 31 19@2x](https://github.com/untitledstartup/convertkit-api-ruby/assets/50114720/13e4f0d8-4ff4-40f1-a827-636fbb16a0f7)
