### PR TITLE
Joel/nav 7992 update add subscriber tag method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.5)
+    convertkit-api-ruby (0.0.6)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/resources/tags.rb
+++ b/lib/convertkit/resources/tags.rb
@@ -27,24 +27,20 @@ module ConvertKit
       end
 
       # Tags a subscriber with the given email address.
-      # See https://developers.convertkit.com/#tag-a-subscriber for details
+      # See https://developers.convertkit.com/v4_alpha.html#convertkit-api-api-alpha-tags-subscriber for details
       # @param [Integer] tag_id
-      # @param [String] email
       # @param [Hash] options
-      # @option options [String] :first_name Subscriber's first name
-      # @option options [Hash] :fields  Key value pairs for existing custom fields
-      # @option options [Array<Integer>] :tags Array of tag ids to subscribe to
-      def add_to_subscriber(tag_id, email, options = {})
+      # @option options [Integer] :id Subscriber Id
+      # @option options [String] :email_address  Subscriber's email address
+      def add_to_subscriber(tag_id, options = {})
         request = {
-          email: email,
-          first_name: options[:first_name],
-          fields: options[:fields],
-          tags: options[:tags]
+          email_address: options[:email_address],
+          id: options[:id]
         }.compact
 
-        response = @client.post("#{PATH}/#{tag_id}/subscribe", request)
+        response = @client.post("#{PATH}/#{tag_id}/subscribers", request, true)
 
-        SubscriptionResponse.new(response)
+        response.success?
       end
 
       # Removes a tag from a subscriber.

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end

--- a/spec/lib/convertkit/resources/tags_spec.rb
+++ b/spec/lib/convertkit/resources/tags_spec.rb
@@ -41,24 +41,28 @@ describe ConvertKit::Resources::Tags do
 
   describe '#add_to_subscriber' do
     let(:tags) { ConvertKit::Resources::Tags.new(client) }
+    let(:response) { double('response', body: '', success?: true) }
 
-    it 'tags a subscriber' do
-      response = {
-        'id' => 1,
-        'state' => 'active',
-        'subscribable_id' => 2,
-        'subscribable_type' => 'tag',
-        'subscriber' => { 'id' => 3 },
-        'created_at' => '2023-08-09T04:30:00Z'
-      }
-      options = {first_name: 'name', fields: { field_key: 'field_value' }, tags:[1,2]}
+    it 'tags a subscriber by id' do
       expect(client).to receive(:post).with(
-        'tags/1/subscribe',
-        { email: 'test_email', first_name: 'name', fields: { field_key: 'field_value' }, tags:[1,2]}
+        'tags/1/subscribers',
+        { id: 2},
+        true
       ).and_return(response)
 
-      subscription_response = tags.add_to_subscriber(1, 'test_email', options)
-      validate_subscription(subscription_response, response)
+      subscription_response = tags.add_to_subscriber(1, {id: 2})
+      expect(subscription_response).to be(true)
+    end
+
+    it 'tags a subscriber by email' do
+      expect(client).to receive(:post).with(
+        'tags/1/subscribers',
+        { email_address: 'test@test.com'},
+        true
+      ).and_return(response)
+
+      subscription_response = tags.add_to_subscriber(1, {email_address: 'test@test.com'})
+      expect(subscription_response).to be(true)
     end
   end
 
@@ -72,7 +76,7 @@ describe ConvertKit::Resources::Tags do
       tag_response = tags.remove_from_subscriber(1, 3)
       validate_tag(tag_response, response)
     end
-  end
+    end
 
   describe '#remove_from_subscriber_by_email' do
     let(:tags) { ConvertKit::Resources::Tags.new(client) }

--- a/spec/lib/convertkit/resources/tags_spec.rb
+++ b/spec/lib/convertkit/resources/tags_spec.rb
@@ -76,7 +76,7 @@ describe ConvertKit::Resources::Tags do
       tag_response = tags.remove_from_subscriber(1, 3)
       validate_tag(tag_response, response)
     end
-    end
+  end
 
   describe '#remove_from_subscriber_by_email' do
     let(:tags) { ConvertKit::Resources::Tags.new(client) }


### PR DESCRIPTION
Update the `add_to_subscriber` method to adhere to the v4 ConvertKit API definition. https://developers.convertkit.com/v4_alpha.html#post_alpha_tags-tag_id-_subscribers