### PR TITLE
Joel/nav 7925 error handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.6)
+    convertkit-api-ruby (0.0.7)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -60,8 +60,12 @@ module ConvertKit
       if response.success?
         raw_response ? response: response.body
       else
-        # TODO add more specific error handling with different error classes
-        raise ConvertKit::APIError, "#{response.status}: #{response.body}"
+        case response.status
+        when 401
+          raise ConvertKit::UnauthorizedError, response.body
+        else
+          raise ConvertKit::APIError, "#{response.status}: #{response.body}"
+        end
       end
     end
   end

--- a/lib/convertkit/error.rb
+++ b/lib/convertkit/error.rb
@@ -5,5 +5,10 @@ module ConvertKit
   class UnsupportedResponseTypeError < StandardError; end
   class InvalidScopeError < StandardError; end
   class OauthError < StandardError; end
+  class UnauthorizedError < StandardError; end
+  class ResourceNotFoundError < StandardError; end
+  class BadDataError < StandardError; end
+  class RateLimitError < StandardError; end
+  class ServerError < StandardError; end
   class APIError < StandardError; end
 end

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end

--- a/spec/lib/convertkit/client_spec.rb
+++ b/spec/lib/convertkit/client_spec.rb
@@ -184,9 +184,13 @@ describe ConvertKit::Client do
     end
 
     context 'when the response is not successful' do
-      let(:response) { double('response', success?: false, body: 'Bad Request', status: 400) }
+      it 'raises an UnauthorizedError' do
+        response = double('response', success?: false, body: '', status: 401)
+        expect { client.send(:handle_response, response) }.to raise_error(ConvertKit::UnauthorizedError)
+      end
 
       it 'raises an APIError' do
+        response = double('response', success?: false, body: 'Bad Request', status: 400)
         expect { client.send(:handle_response, response) }.to raise_error(ConvertKit::APIError, '400: Bad Request')
       end
     end

--- a/spec/lib/convertkit/connection_spec.rb
+++ b/spec/lib/convertkit/connection_spec.rb
@@ -11,7 +11,7 @@ describe ConvertKit::Connection do
   describe '#get' do
     let!(:connection) { double('connection') }
     let!(:env) { double('Env', body: '{"message":"response_hash"}') }
-    let!(:response) { double('response', env: env ) }
+    let!(:response) { double('response', env: env, status: 200 ) }
 
     before do
       allow(Faraday).to receive(:new).and_return(connection)
@@ -29,7 +29,7 @@ describe ConvertKit::Connection do
   describe '#post' do
     let!(:connection) { double('connection') }
     let!(:env) { double('Env', body: '{"message":"response_hash"}') }
-    let!(:response) { double('response', env: env ) }
+    let!(:response) { double('response', env: env, status: 200 ) }
 
     before do
       allow(Faraday).to receive(:new).and_return(connection)
@@ -47,7 +47,7 @@ describe ConvertKit::Connection do
   describe '#delete' do
     let!(:connection) { double('connection') }
     let!(:env) { double('Env', body: '{"message":"response_hash"}') }
-    let!(:response) { double('response', env: env ) }
+    let!(:response) { double('response', env: env, status: 200 ) }
 
     before do
       allow(Faraday).to receive(:new).and_return(connection)
@@ -65,7 +65,7 @@ describe ConvertKit::Connection do
   describe '#put' do
     let!(:connection) { double('connection') }
     let!(:env) { double('Env', body: '{"message":"response_hash"}') }
-    let!(:response) { double('response', env: env ) }
+    let!(:response) { double('response', env: env, status: 200 ) }
 
     before do
       allow(Faraday).to receive(:new).and_return(connection)


### PR DESCRIPTION
Added specific error for better error handling. In the[ v4 ConvertKit API documentation](https://developers.convertkit.com/v4_alpha.html#api-basics), it mentions 4 errors that are now specifically handled in the `Connection` class, since the errors can occur for both the `Client` class or `OAuth` classes. Any errors that only occur or are only relevant to either the `Client` or `OAuth` class are handled locally.