### PR TITLE
Joel/nav 8036 add server errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.7)
+    convertkit-api-ruby (0.0.8)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/connection.rb
+++ b/lib/convertkit/connection.rb
@@ -46,6 +46,12 @@ module ConvertKit
         raise ConvertKit::RateLimitError, response.body
       when 500
         raise ConvertKit::ServerError, response.body
+      when 502
+        raise ConvertKit::BadGatewayError, response.body
+      when 503
+        raise ConvertKit::ServiceUnavailableError, response.body
+      when 504
+        raise ConvertKit::GatewayTimeoutError, response.body
       else
         response # Let the caller handle the response
       end

--- a/lib/convertkit/error.rb
+++ b/lib/convertkit/error.rb
@@ -10,5 +10,8 @@ module ConvertKit
   class BadDataError < StandardError; end
   class RateLimitError < StandardError; end
   class ServerError < StandardError; end
+  class BadGatewayError < StandardError; end
+  class ServiceUnavailableError < StandardError; end
+  class GatewayTimeoutError < StandardError; end
   class APIError < StandardError; end
 end

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end

--- a/spec/lib/convertkit/connection_spec.rb
+++ b/spec/lib/convertkit/connection_spec.rb
@@ -123,5 +123,32 @@ describe ConvertKit::Connection do
 
       expect { ConvertKit::Connection.new(url).post('test_path', {hash: 'request_hash'}) }.to raise_error(ConvertKit::ServerError, message)
     end
+
+    it 'raises an BadGatewayError' do
+      message = '{"errors": "Internal Server Error"}'
+      response = double('response', env: double('Env', body: message), body: message, status: 502)
+      allow(response.env).to receive(:body=)
+      allow(connection).to receive(:post).and_return(response)
+
+      expect { ConvertKit::Connection.new(url).post('test_path', {hash: 'request_hash'}) }.to raise_error(ConvertKit::BadGatewayError, message)
+    end
+
+    it 'raises an ServiceUnavailableError' do
+      message = '{"errors": "Internal Server Error"}'
+      response = double('response', env: double('Env', body: message), body: message, status: 503)
+      allow(response.env).to receive(:body=)
+      allow(connection).to receive(:post).and_return(response)
+
+      expect { ConvertKit::Connection.new(url).post('test_path', {hash: 'request_hash'}) }.to raise_error(ConvertKit::ServiceUnavailableError, message)
+    end
+
+    it 'raises an GatewayTimeoutError' do
+      message = '{"errors": "Internal Server Error"}'
+      response = double('response', env: double('Env', body: message), body: message, status: 504)
+      allow(response.env).to receive(:body=)
+      allow(connection).to receive(:post).and_return(response)
+
+      expect { ConvertKit::Connection.new(url).post('test_path', {hash: 'request_hash'}) }.to raise_error(ConvertKit::GatewayTimeoutError, message)
+    end
   end
 end

--- a/spec/lib/convertkit/connection_spec.rb
+++ b/spec/lib/convertkit/connection_spec.rb
@@ -125,7 +125,7 @@ describe ConvertKit::Connection do
     end
 
     it 'raises an BadGatewayError' do
-      message = '{"errors": "Internal Server Error"}'
+      message = ''
       response = double('response', env: double('Env', body: message), body: message, status: 502)
       allow(response.env).to receive(:body=)
       allow(connection).to receive(:post).and_return(response)
@@ -134,7 +134,7 @@ describe ConvertKit::Connection do
     end
 
     it 'raises an ServiceUnavailableError' do
-      message = '{"errors": "Internal Server Error"}'
+      message = ''
       response = double('response', env: double('Env', body: message), body: message, status: 503)
       allow(response.env).to receive(:body=)
       allow(connection).to receive(:post).and_return(response)
@@ -143,7 +143,7 @@ describe ConvertKit::Connection do
     end
 
     it 'raises an GatewayTimeoutError' do
-      message = '{"errors": "Internal Server Error"}'
+      message = ''
       response = double('response', env: double('Env', body: message), body: message, status: 504)
       allow(response.env).to receive(:body=)
       allow(connection).to receive(:post).and_return(response)


### PR DESCRIPTION
Add a error handling for 50X http status codes. This will raise ConvertKit specific errors that  can be helpful to handle each scenario separately and with an easy reference to an error. 

Local Green Build:
![CleanShot 2023-10-11 at 21 03 23@2x](https://github.com/untitledstartup/convertkit-api-ruby/assets/50114720/6b4e69fc-813a-40f6-9ed0-5e7102e87edb)
