### PR TITLE
Joel/nav 7817 revoke support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.8)
+    convertkit-api-ruby (0.0.9)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'
 end


### PR DESCRIPTION
Add support for revoking an OAuth token. As a security measure, tokens that are no longer needed should be revoked. The PR makes this possible.

Local Green Build:
![CleanShot 2023-10-11 at 21 02 27@2x](https://github.com/untitledstartup/convertkit-api-ruby/assets/50114720/189a40c6-298d-400c-b02a-fcc2349a4654)

