### PR TITLE
Joel/nav 8036 add server errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.8)
+    convertkit-api-ruby (0.0.9)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'
 end


### PR DESCRIPTION
PR https://github.com/untitledstartup/convertkit-api-ruby/pull/18 should have merged to main but rather merged to https://github.com/untitledstartup/convertkit-api-ruby/pull/17 (joel/nav_8036_add_server_errors) and so need to merge this branch to main again.

See PR https://github.com/untitledstartup/convertkit-api-ruby/pull/18 for details about the changes in this PR.