### PR TITLE
Joel/nav 8090 bulk create response change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.9)
+    convertkit-api-ruby (0.0.10)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/resources/subscriber_bulk_create_failure_response.rb
+++ b/lib/convertkit/resources/subscriber_bulk_create_failure_response.rb
@@ -1,10 +1,10 @@
 module ConvertKit
   module Resources
     class SubscriberBulkCreateFailureResponse
-      attr_accessor :body, :errors
+      attr_accessor :subscriber, :errors
 
       def initialize(response)
-        @body = response['body']
+        @subscriber = SubscriberResponse.new(response['subscriber']) if response['subscriber']
         @errors = response['errors']
       end
     end

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end

--- a/spec/lib/convertkit/resources/subscriber_bulk_create_response_spec.rb
+++ b/spec/lib/convertkit/resources/subscriber_bulk_create_response_spec.rb
@@ -17,7 +17,21 @@ describe ConvertKit::Resources::SubscriberBulkCreateResponse do
         'subscribers' => [],
         'failures' => [
           {
-            body: { 'first_name' => 'test_user'},
+            subscriber: { 'first_name' => 'test_user' },
+            errors: ['Email address cannot be blank', 'Email address is invalid']
+          }
+        ]
+      }
+
+      bulk_create_response = ConvertKit::Resources::SubscriberBulkCreateResponse.new(response)
+      validate_bulk_create(bulk_create_response, response)
+    end
+
+    it 'sets the failures with subscriber data missing' do
+      response = {
+        'subscribers' => [],
+        'failures' => [
+          {
             errors: ['Email address cannot be blank', 'Email address is invalid']
           }
         ]
@@ -32,7 +46,7 @@ describe ConvertKit::Resources::SubscriberBulkCreateResponse do
         'subscribers' => [{ 'id' => 1, 'first_name' => 'test_user', 'email' => 'test@test.com', 'state' => 'active'}],
         'failures' => [
           {
-            body: { 'first_name' => 'test_user'},
+            subscriber: { 'first_name' => 'test_user'},
             errors: ['Email address cannot be blank', 'Email address is invalid']
           }
         ]

--- a/spec/validators/subscriber_validators.rb
+++ b/spec/validators/subscriber_validators.rb
@@ -20,8 +20,8 @@ module Validators
     end
 
     def validate_bulk_create_failure(bulk_create_failure_response, values)
-      expect(bulk_create_failure_response.body).to eq(values['body'])
       expect(bulk_create_failure_response.errors).to match_array(values['errors']) if values['errors']
+      validate_subscriber(bulk_create_failure_response.subscriber, values['subscriber']) if values['subscriber']
     end
 
     def validate_bulk_create(bulk_create_response, values)


### PR DESCRIPTION
The response for bulk create endpoint for subscribers has changed. In the failures attribute it will no longer return `body` but rather `subscriber`. This PR address this change. Here's sample of an appropriate response:


```
subscribers: [
  {
    id: 123
    name: "Good",
    email_address: "good@email.com",
    state: "active"
  },
  {
    // more subscribers
  }
],
failures: [
  subscriber: {
    name: "",
    email_address: "bad@email",
    state: "active"
  },
  errors: ["Invalid email"]
]
```