### PR TITLE
Joel/nav 8034 update remove tag endpoint v4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.10)
+    convertkit-api-ruby (0.0.11)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/connection.rb
+++ b/lib/convertkit/connection.rb
@@ -18,7 +18,14 @@ module ConvertKit
     # Defined wrapper methods for Faraday's HTTP methods
     HTTP_METHODS.each do |method|
       define_method(method) do |path, params = {}|
-        response = @connection.public_send(method, path, process_request(method, params))
+        # Allow delete requests to have a body. See https://github.com/lostisland/faraday/issues/693#issuecomment-466086832
+        if method == :delete
+          response = @connection.public_send(method, path) do |request|
+            request.body = process_request(method, params)
+          end
+        else
+          response = @connection.public_send(method, path, process_request(method, params))
+        end
         process_response(response)
       end
     end

--- a/lib/convertkit/resources/tags.rb
+++ b/lib/convertkit/resources/tags.rb
@@ -59,16 +59,6 @@ module ConvertKit
         response.success?
       end
 
-      # Removes a tag from a subscriber using an email address.
-      # See https://developers.convertkit.com/#remove-tag-from-a-subscriber-by-email for details.
-      # @param [Integer] tag_id
-      # @param [String] subscriber_email
-      def remove_from_subscriber_by_email(tag_id, subscriber_email)
-        response = @client.post("#{PATH}/#{tag_id}/unsubscribe", { email: subscriber_email})
-
-        TagResponse.new(response)
-      end
-
       # Returns a list of subscriptions for a given tag.
       # See https://developers.convertkit.com/#list-subscriptions-to-a-tag for details.
       # @param [Integer] tag_id

--- a/lib/convertkit/resources/tags.rb
+++ b/lib/convertkit/resources/tags.rb
@@ -44,13 +44,19 @@ module ConvertKit
       end
 
       # Removes a tag from a subscriber.
-      # See https://developers.convertkit.com/#remove-tag-from-a-subscriber for details.
+      # See https://developers.convertkit.com/v4_alpha.html#delete_alpha_tags-tag_id-_subscribers for details.
       # @param [Integer] tag_id
-      # @param [Integer] subscriber_id
-      def remove_from_subscriber(tag_id, subscriber_id)
-        response = @client.delete("subscribers/#{subscriber_id}/#{PATH}/#{tag_id}")
+      # @param [Hash] options
+      # @option options [Integer] :id Subscriber Id
+      # @option options [String] :email_address  Subscriber's email address
+      def remove_from_subscriber(tag_id, options = {})
+        request = {
+          email_address: options[:email_address],
+          id: options[:id]
+        }.compact
+        response = @client.delete("#{PATH}/#{tag_id}/subscribers", request, true)
 
-        TagResponse.new(response)
+        response.success?
       end
 
       # Removes a tag from a subscriber using an email address.

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end

--- a/spec/lib/convertkit/connection_spec.rb
+++ b/spec/lib/convertkit/connection_spec.rb
@@ -45,17 +45,23 @@ describe ConvertKit::Connection do
   end
 
   describe '#delete' do
-    let!(:connection) { double('connection') }
+    let!(:builder) { double('builder') }
     let!(:env) { double('Env', body: '{"message":"response_hash"}') }
     let!(:response) { double('response', env: env, status: 200 ) }
 
     before do
-      allow(Faraday).to receive(:new).and_return(connection)
+      allow(Faraday::RackBuilder).to receive(:new).and_return(builder)
       allow(response).to receive(:body).and_return(response.env.body)
     end
 
     it 'calls the get method on the connection' do
-      expect(connection).to receive(:delete).with('test_path', '{"hash":"request_hash"}').and_return(response)
+      expect_any_instance_of(Faraday::Connection).to receive(:delete).with('test_path').and_call_original
+      expect(builder).to receive(:build_response) do |connection, request|
+        expect(request.path).to eq('test_path')
+        expect(request.method).to eq(:delete)
+        expect(request.body).to eq('{"hash":"request_hash"}')
+      end.and_return(response)
+
       allow(env).to receive(:body=).with({"message" => "response_hash"})
 
       ConvertKit::Connection.new(url).delete('test_path', {hash: 'request_hash'})

--- a/spec/lib/convertkit/resources/tags_spec.rb
+++ b/spec/lib/convertkit/resources/tags_spec.rb
@@ -68,25 +68,18 @@ describe ConvertKit::Resources::Tags do
 
   describe '#remove_from_subscriber' do
     let(:tags) { ConvertKit::Resources::Tags.new(client) }
+    let(:response) { double('response', body: '', success?: true) }
 
-    it 'removes a tag from a subscriber' do
-      response = { 'id' => 1, 'name' => 'test_tag_name', 'created_at' => '2023-08-09T04:30:00Z' }
-      expect(client).to receive(:delete).with('subscribers/3/tags/1').and_return(response)
+    it 'removes a tag from a subscriber by id' do
+      expect(client).to receive(:delete).with('tags/1/subscribers', {id: 3}, true).and_return(response)
 
-      tag_response = tags.remove_from_subscriber(1, 3)
-      validate_tag(tag_response, response)
+      expect(tags.remove_from_subscriber(1, id: 3)).to eq true
     end
-  end
 
-  describe '#remove_from_subscriber_by_email' do
-    let(:tags) { ConvertKit::Resources::Tags.new(client) }
+    it 'removes a tag from a subscriber by email' do
+      expect(client).to receive(:delete).with('tags/1/subscribers', {email_address: 'test@test.com'}, true).and_return(response)
 
-    it 'removes a tag from a subscriber' do
-      response = { 'id' => 1, 'name' => 'test_tag_name', 'created_at' => '2023-08-09T04:30:00Z' }
-      expect(client).to receive(:post).with('tags/1/unsubscribe', { email: 'test@test.com' }).and_return(response)
-
-      tag_response = tags.remove_from_subscriber_by_email(1, 'test@test.com')
-      validate_tag(tag_response, response)
+      expect(tags.remove_from_subscriber(1, email_address: 'test@test.com')).to eq true
     end
   end
 


### PR DESCRIPTION
Updated the endpoint that removes a tag from a subscriber. This been modified in v4 and the details are [here](https://developers.convertkit.com/v4_alpha.html#delete_alpha_tags-tag_id-_subscribers). The endpoint uses the `delete` method but also requires a body to be defined. In order to support this with Faraday, it requires that you set the body in a block to the delete method(See https://github.com/lostisland/faraday/issues/693#issuecomment-466086832).

State of specs:
![CleanShot 2023-10-19 at 18 02 45@2x](https://github.com/untitledstartup/convertkit-api-ruby/assets/50114720/2a8d408b-b8f1-47a7-9a21-5eb9726b9a95)
