### PR TITLE
Start transition to v4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    convertkit-api-ruby (0.0.11)
+    convertkit-api-ruby (0.0.12)
       faraday (>= 1.0, < 3.0)
 
 GEM

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -3,7 +3,7 @@ module ConvertKit
   # Without a valid token, the client will not be able to retrieve data from the API.
   # The ConvertKit OAuth class can be used to obtain this token.
   class Client
-    API_URL = 'https://api.convertkit.com/alpha'.freeze # Using Alpha API as this is currently in active development
+    API_URL = 'https://api.convertkit.com/v4'.freeze # Using Alpha API as this is currently in active development
     HTTP_METHODS = %i[get post delete put].freeze
 
     def initialize(auth_token)

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -3,7 +3,7 @@ module ConvertKit
   # Without a valid token, the client will not be able to retrieve data from the API.
   # The ConvertKit OAuth class can be used to obtain this token.
   class Client
-    API_URL = 'https://api.convertkit.com/v4'.freeze # Using Alpha API as this is currently in active development
+    API_URL = 'https://api.convertkit.com/v4'.freeze
     HTTP_METHODS = %i[get post delete put].freeze
 
     def initialize(auth_token)

--- a/lib/convertkit/resources/tags.rb
+++ b/lib/convertkit/resources/tags.rb
@@ -31,7 +31,7 @@ module ConvertKit
       # @param [Integer] tag_id
       # @param [Integer] subscriber_id
       def add_to_subscriber(tag_id, subscriber_id)
-        response = @client.post("#{PATH}/#{tag_id}/subscribers/#{subscriber_id}", {}, true)
+        response = @client.post("#{PATH}/#{tag_id}/subscribers/#{subscriber_id}", '', true)
 
         response.success?
       end
@@ -40,11 +40,12 @@ module ConvertKit
       # See https://developers.convertkit.com/v4.html#tag-a-subscriber-by-email-address for details
       # @param [Integer] tag_id
       # @param [String] email_address
-      # @param [Integer] subscriber_id
-      def add_to_subscriber_by_email_address(tag_id, email_address, subscriber_id = nil)
+      # @param [Hash] options
+      # @option options [Integer] :subscriber_id
+      def add_to_subscriber_by_email_address(tag_id, email_address, options = {})
         request = {
           email_address: email_address,
-          id: subscriber_id
+          id: options[:subscriber_id]
         }.compact
         response = @client.post("#{PATH}/#{tag_id}/subscribers", request, true)
 
@@ -56,7 +57,7 @@ module ConvertKit
       # @param [Integer] tag_id
       # @param [Integer] subscriber_id
       def remove_from_subscriber(tag_id, subscriber_id)
-        response = @client.delete("#{PATH}/#{tag_id}/subscribers/#{subscriber_id}", {}, true)
+        response = @client.delete("#{PATH}/#{tag_id}/subscribers/#{subscriber_id}", '', true)
 
         response.success?
       end

--- a/lib/convertkit/resources/tags.rb
+++ b/lib/convertkit/resources/tags.rb
@@ -26,35 +26,47 @@ module ConvertKit
         TagResponse.new(response)
       end
 
-      # Tags a subscriber with the given email address.
-      # See https://developers.convertkit.com/v4_alpha.html#convertkit-api-api-alpha-tags-subscriber for details
+      # Tags a subscriber
+      # See https://developers.convertkit.com/v4.html#tag-a-subscriber for details
       # @param [Integer] tag_id
-      # @param [Hash] options
-      # @option options [Integer] :id Subscriber Id
-      # @option options [String] :email_address  Subscriber's email address
-      def add_to_subscriber(tag_id, options = {})
-        request = {
-          email_address: options[:email_address],
-          id: options[:id]
-        }.compact
+      # @param [Integer] subscriber_id
+      def add_to_subscriber(tag_id, subscriber_id)
+        response = @client.post("#{PATH}/#{tag_id}/subscribers/#{subscriber_id}", {}, true)
 
+        response.success?
+      end
+
+      # Tag a subscriber by email address
+      # See https://developers.convertkit.com/v4.html#tag-a-subscriber-by-email-address for details
+      # @param [Integer] tag_id
+      # @param [String] email_address
+      # @param [Integer] subscriber_id
+      def add_to_subscriber_by_email_address(tag_id, email_address, subscriber_id = nil)
+        request = {
+          email_address: email_address,
+          id: subscriber_id
+        }.compact
         response = @client.post("#{PATH}/#{tag_id}/subscribers", request, true)
 
         response.success?
       end
 
       # Removes a tag from a subscriber.
-      # See https://developers.convertkit.com/v4_alpha.html#delete_alpha_tags-tag_id-_subscribers for details.
+      # See https://developers.convertkit.com/v4.html#remove-tag-from-subscriber for details.
       # @param [Integer] tag_id
-      # @param [Hash] options
-      # @option options [Integer] :id Subscriber Id
-      # @option options [String] :email_address  Subscriber's email address
-      def remove_from_subscriber(tag_id, options = {})
-        request = {
-          email_address: options[:email_address],
-          id: options[:id]
-        }.compact
-        response = @client.delete("#{PATH}/#{tag_id}/subscribers", request, true)
+      # @param [Integer] subscriber_id
+      def remove_from_subscriber(tag_id, subscriber_id)
+        response = @client.delete("#{PATH}/#{tag_id}/subscribers/#{subscriber_id}", {}, true)
+
+        response.success?
+      end
+
+      # Removes a tag from a subscriber by email address.
+      # See https://developers.convertkit.com/v4.html#remove-tag-from-subscriber-by-email-address for details
+      # @param [Integer] tag_id
+      # @param [String] email_address
+      def remove_from_subscriber_by_email_address(tag_id, email_address)
+        response = @client.delete("#{PATH}/#{tag_id}/subscribers", { email_address: email_address }, true)
 
         response.success?
       end

--- a/lib/convertkit/version.rb
+++ b/lib/convertkit/version.rb
@@ -1,3 +1,3 @@
 module ConvertKit
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
 end

--- a/spec/lib/convertkit/resources/tags_spec.rb
+++ b/spec/lib/convertkit/resources/tags_spec.rb
@@ -45,14 +45,19 @@ describe ConvertKit::Resources::Tags do
 
     it 'tags a subscriber by id' do
       expect(client).to receive(:post).with(
-        'tags/1/subscribers',
-        { id: 2},
+        'tags/1/subscribers/2',
+        {},
         true
       ).and_return(response)
 
-      subscription_response = tags.add_to_subscriber(1, {id: 2})
+      subscription_response = tags.add_to_subscriber(1, 2)
       expect(subscription_response).to be(true)
     end
+  end
+
+  describe '#add_to_subscriber_by_email_address' do
+    let(:tags) { ConvertKit::Resources::Tags.new(client) }
+    let(:response) { double('response', body: '', success?: true) }
 
     it 'tags a subscriber by email' do
       expect(client).to receive(:post).with(
@@ -61,7 +66,20 @@ describe ConvertKit::Resources::Tags do
         true
       ).and_return(response)
 
-      subscription_response = tags.add_to_subscriber(1, {email_address: 'test@test.com'})
+      subscription_response = tags.add_to_subscriber_by_email_address(1, 'test@test.com')
+      expect(subscription_response).to be(true)
+    end
+
+    it 'tags a subscriber by email with subscriber id included' do
+      expect(client).to receive(:post).with(
+        'tags/1/subscribers',
+        { email_address: 'test@test.com',
+          id: 2
+        },
+        true
+      ).and_return(response)
+
+      subscription_response = tags.add_to_subscriber_by_email_address(1, 'test@test.com', 2)
       expect(subscription_response).to be(true)
     end
   end
@@ -71,15 +89,20 @@ describe ConvertKit::Resources::Tags do
     let(:response) { double('response', body: '', success?: true) }
 
     it 'removes a tag from a subscriber by id' do
-      expect(client).to receive(:delete).with('tags/1/subscribers', {id: 3}, true).and_return(response)
+      expect(client).to receive(:delete).with('tags/1/subscribers/3', {}, true).and_return(response)
 
-      expect(tags.remove_from_subscriber(1, id: 3)).to eq true
+      expect(tags.remove_from_subscriber(1, 3)).to eq true
     end
+  end
+
+  describe '#remove_from_subscriber_by_email_address' do
+    let(:tags) { ConvertKit::Resources::Tags.new(client) }
+    let(:response) { double('response', body: '', success?: true) }
 
     it 'removes a tag from a subscriber by email' do
       expect(client).to receive(:delete).with('tags/1/subscribers', {email_address: 'test@test.com'}, true).and_return(response)
 
-      expect(tags.remove_from_subscriber(1, email_address: 'test@test.com')).to eq true
+      expect(tags.remove_from_subscriber_by_email_address(1, 'test@test.com')).to eq true
     end
   end
 

--- a/spec/lib/convertkit/resources/tags_spec.rb
+++ b/spec/lib/convertkit/resources/tags_spec.rb
@@ -46,7 +46,7 @@ describe ConvertKit::Resources::Tags do
     it 'tags a subscriber by id' do
       expect(client).to receive(:post).with(
         'tags/1/subscribers/2',
-        {},
+        '',
         true
       ).and_return(response)
 
@@ -79,7 +79,7 @@ describe ConvertKit::Resources::Tags do
         true
       ).and_return(response)
 
-      subscription_response = tags.add_to_subscriber_by_email_address(1, 'test@test.com', 2)
+      subscription_response = tags.add_to_subscriber_by_email_address(1, 'test@test.com', {subscriber_id: 2})
       expect(subscription_response).to be(true)
     end
   end
@@ -89,7 +89,7 @@ describe ConvertKit::Resources::Tags do
     let(:response) { double('response', body: '', success?: true) }
 
     it 'removes a tag from a subscriber by id' do
-      expect(client).to receive(:delete).with('tags/1/subscribers/3', {}, true).and_return(response)
+      expect(client).to receive(:delete).with('tags/1/subscribers/3', '', true).and_return(response)
 
       expect(tags.remove_from_subscriber(1, 3)).to eq true
     end


### PR DESCRIPTION
Started transitioning to v4 of the [ConvertKit API](https://developers.convertkit.com/v4.html). The initial work changes the main API path and updates critical breaking changes involving tags. The API endpoint to add or remove a tag from a subscriber was split into two methods, one that accepts just a subscriber id and another that accepts an email address. 

Here are links to the endpoint definitions:
https://developers.convertkit.com/v4.html#tag-a-subscriber
https://developers.convertkit.com/v4.html#tag-a-subscriber-by-email-address
https://developers.convertkit.com/v4.html#remove-tag-from-subscriber
https://developers.convertkit.com/v4.html#remove-tag-from-subscriber-by-email-address

I've manually tested the subscriber and tag endpoints as well and have also added specs for the above changes.

Manually tested flows:
- Create a subscriber
- Bulk create subscribers
- List subscribers
- List a subscribers tags
- Create a Tag
- Add a tag to a subscriber by subscriber id
- Add a tag to a subscriber by email address
- Remove a tag from a subscriber by subscriber id
- Remove a tag from a subscriber by email address

![CleanShot 2024-04-18 at 13 41 19@2x](https://github.com/untitledstartup/convertkit-api-ruby/assets/50114720/97dbf83a-28f2-40c4-8504-44b704023f8f)
