### PR TITLE
Send /oauth/revoke as form-encoded per RFC 7009

### DIFF
--- a/lib/convertkit/oauth.rb
+++ b/lib/convertkit/oauth.rb
@@ -7,9 +7,11 @@ module ConvertKit
   class OAuth
     URL = 'https://app.convertkit.com/'.freeze
     TOKEN_PATH = 'oauth/token'.freeze
-    # RFC 7009 token revocation endpoint. Lives under api.kit.com/v4 (not the legacy app.convertkit.com host)
-    # and requires application/x-www-form-urlencoded — see https://developers.kit.com/api-reference/oauth-token-revocation
-    REVOKE_URL = 'https://api.kit.com/v4/oauth/revoke'.freeze
+    # RFC 7009 token revocation endpoint. Requires application/x-www-form-urlencoded — see
+    # https://developers.kit.com/api-reference/oauth-token-revocation. Kit's docs name api.kit.com/v4
+    # as the canonical host; we stay on app.convertkit.com so the OAuth flow is host-consistent
+    # across authorize / token / revoke. Migrate when Kit deprecates the legacy host.
+    REVOKE_URL = 'https://app.convertkit.com/oauth/revoke'.freeze
 
     def initialize(client_id, client_secret, options = {})
       @id = client_id

--- a/lib/convertkit/oauth.rb
+++ b/lib/convertkit/oauth.rb
@@ -7,11 +7,7 @@ module ConvertKit
   class OAuth
     URL = 'https://app.convertkit.com/'.freeze
     TOKEN_PATH = 'oauth/token'.freeze
-    # RFC 7009 token revocation endpoint. Requires application/x-www-form-urlencoded — see
-    # https://developers.kit.com/api-reference/oauth-token-revocation. Kit's docs name api.kit.com/v4
-    # as the canonical host; we stay on app.convertkit.com so the OAuth flow is host-consistent
-    # across authorize / token / revoke. Migrate when Kit deprecates the legacy host.
-    REVOKE_URL = 'https://app.convertkit.com/oauth/revoke'.freeze
+    REVOKE_PATH = 'oauth/revoke'.freeze
 
     def initialize(client_id, client_secret, options = {})
       @id = client_id
@@ -47,13 +43,13 @@ module ConvertKit
       AccessTokenResponse.new(response)
     end
 
-    # POSTs a form-encoded RFC 7009 revoke request directly via Net::HTTP. The gem's Connection
-    # class sends application/json, which Kit's /oauth/revoke cannot parse; per RFC 7009 the endpoint
-    # returns 200 even for unparseable requests, so any Content-Type other than form-encoded would
-    # silently no-op without actually revoking the token.
+    # POSTs a form-encoded RFC 7009 revoke request via Net::HTTP. The gem's Connection class
+    # sends application/json, which Kit's /oauth/revoke cannot parse; per RFC 7009 the endpoint
+    # returns 200 even for unparseable requests, so any Content-Type other than form-encoded
+    # would silently no-op without actually revoking the token.
     def revoke_token(token)
       response = Net::HTTP.post_form(
-        URI(REVOKE_URL),
+        URI.join(URL, REVOKE_PATH),
         token: token,
         client_id: @id,
         client_secret: @secret,

--- a/lib/convertkit/oauth.rb
+++ b/lib/convertkit/oauth.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module ConvertKit
   # Use this class to get an access token or refresh token using the OAuth2 flow. The client id and client secret
   # should be obtained from ConvertKit and is required for this flow. The code should be obtained when initially connect
@@ -5,7 +7,9 @@ module ConvertKit
   class OAuth
     URL = 'https://app.convertkit.com/'.freeze
     TOKEN_PATH = 'oauth/token'.freeze
-    REVOKE_PATH = 'oauth/revoke'.freeze
+    # RFC 7009 token revocation endpoint. Lives under api.kit.com/v4 (not the legacy app.convertkit.com host)
+    # and requires application/x-www-form-urlencoded — see https://developers.kit.com/api-reference/oauth-token-revocation
+    REVOKE_URL = 'https://api.kit.com/v4/oauth/revoke'.freeze
 
     def initialize(client_id, client_secret, options = {})
       @id = client_id
@@ -41,15 +45,24 @@ module ConvertKit
       AccessTokenResponse.new(response)
     end
 
+    # POSTs a form-encoded RFC 7009 revoke request directly via Net::HTTP. The gem's Connection
+    # class sends application/json, which Kit's /oauth/revoke cannot parse; per RFC 7009 the endpoint
+    # returns 200 even for unparseable requests, so any Content-Type other than form-encoded would
+    # silently no-op without actually revoking the token.
     def revoke_token(token)
-      params = {
+      response = Net::HTTP.post_form(
+        URI(REVOKE_URL),
+        token: token,
         client_id: @id,
         client_secret: @secret,
-        token: token
-      }
+        token_type_hint: 'access_token'
+      )
 
-      response = handle_response(@connection.post(REVOKE_PATH, params), true)
-      response.success?
+      unless response.code.to_i.between?(200, 299)
+        raise ConvertKit::OauthError, "Kit /oauth/revoke returned HTTP #{response.code}: #{response.body}"
+      end
+
+      true
     end
 
     private

--- a/spec/lib/convertkit/oauth_spec.rb
+++ b/spec/lib/convertkit/oauth_spec.rb
@@ -130,22 +130,42 @@ describe ConvertKit::OAuth do
 
   describe '#revoke_token' do
     let(:oauth) { ConvertKit::OAuth.new(client_id, client_secret, redirect_uri: redirect_uri, code: code, refresh_token: refresh_token) }
-    let(:revoke_path) { 'oauth/revoke' }
+    let(:revoke_uri) { URI('https://api.kit.com/v4/oauth/revoke') }
     let(:token) { 'random_token' }
+    let(:net_response) { double('net_response') }
 
     before do
       allow(ConvertKit::Connection).to receive(:new).with(url).and_return(connection)
-      allow(response).to receive(:success?).and_return(true)
     end
 
-    it 'returns success response' do
-      expect(connection).to receive(:post).with(revoke_path, {
-        client_id: client_id,
-        client_secret: client_secret,
-        token: token,
-      }).and_return(response)
+    context 'when Kit returns 2xx' do
+      before do
+        allow(net_response).to receive(:code).and_return('200')
+      end
 
-      expect(oauth.revoke_token(token)).to eq(true)
+      it 'POSTs form-encoded params to api.kit.com/v4/oauth/revoke and returns true' do
+        expect(Net::HTTP).to receive(:post_form).with(
+          revoke_uri,
+          token: token,
+          client_id: client_id,
+          client_secret: client_secret,
+          token_type_hint: 'access_token'
+        ).and_return(net_response)
+
+        expect(oauth.revoke_token(token)).to eq(true)
+      end
+    end
+
+    context 'when Kit returns a non-2xx response' do
+      before do
+        allow(net_response).to receive(:code).and_return('401')
+        allow(net_response).to receive(:body).and_return('{"error":"unauthorized"}')
+        allow(Net::HTTP).to receive(:post_form).and_return(net_response)
+      end
+
+      it 'raises ConvertKit::OauthError including the HTTP status and body' do
+        expect { oauth.revoke_token(token) }.to raise_error(ConvertKit::OauthError, /401.*unauthorized/)
+      end
     end
   end
 

--- a/spec/lib/convertkit/oauth_spec.rb
+++ b/spec/lib/convertkit/oauth_spec.rb
@@ -130,7 +130,7 @@ describe ConvertKit::OAuth do
 
   describe '#revoke_token' do
     let(:oauth) { ConvertKit::OAuth.new(client_id, client_secret, redirect_uri: redirect_uri, code: code, refresh_token: refresh_token) }
-    let(:revoke_uri) { URI('https://api.kit.com/v4/oauth/revoke') }
+    let(:revoke_uri) { URI('https://app.convertkit.com/oauth/revoke') }
     let(:token) { 'random_token' }
     let(:net_response) { double('net_response') }
 
@@ -143,7 +143,7 @@ describe ConvertKit::OAuth do
         allow(net_response).to receive(:code).and_return('200')
       end
 
-      it 'POSTs form-encoded params to api.kit.com/v4/oauth/revoke and returns true' do
+      it 'POSTs form-encoded params to app.convertkit.com/oauth/revoke and returns true' do
         expect(Net::HTTP).to receive(:post_form).with(
           revoke_uri,
           token: token,


### PR DESCRIPTION
## Summary

Rewrite `ConvertKit::OAuth#revoke_token` to POST `application/x-www-form-urlencoded` instead of `application/json`. Same host as the rest of the OAuth flow (`app.convertkit.com`), same method signature for callers — only the Content-Type and a few RFC-7009-shaped semantics around it change. The previous JSON-bodied implementation had been silently no-op'ing every revoke for over a year.

## Problem

Kit's `/oauth/revoke` is a standard [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) endpoint. Two clauses in the spec combine to make the previous code path silently broken:

- **§2.1 — Request format.** Clients MUST POST `application/x-www-form-urlencoded`. The gem's `Connection` class sends `Content-Type: application/json` and a JSON body. Kit's parser cannot read what we send.
- **§2.2 — Server response.** When the server cannot identify the supplied token — because the request was unparseable, the token doesn't exist, or the client submitted nothing at all — it MUST still return HTTP 200. The spec is explicit: *"The authorization server responds with HTTP status code 200 if the token has been revoked successfully or if the client submitted an invalid token."*

So every JSON-bodied revoke from the gem got HTTP 200 back from Kit's edge with no token actually invalidated. `revoke_token` returned `response.success?` (which was `true`), Speckel's caller logged `Kit /oauth/revoke succeeded`, and Kit's database stayed untouched.

Kit engineer's confirmation:

> If the forked gem is posting JSON (or otherwise not form-encoded), that's the bug: we can't parse the token, so per RFC we return 200 without resolving anything, which is why the disconnect looks successful on your side but never lands on ours.

Kit API doc: https://developers.kit.com/api-reference/oauth-token-revocation

## Production Evidence

OpenSearch logs, 2026-06-08 23:04–23:07 UTC, network 12165494 — four full disconnect cycles. Each cycle emitted the gem's own success log lines:

```
ConvertKitService.revoke_token_for_provider: calling Kit /oauth/revoke for kit
ConvertKitService.revoke_token_for_provider: Kit /oauth/revoke succeeded for kit
```

Kit's engineer confirmed they observed zero parseable revoke requests across the same window. The tokens remained valid server-side.

The post-merge state for the same scenario: identical pre-call log, identical success log when Kit returns 200, but Kit's records reflect actual revocation. Failure modes (non-2xx from Kit) flip from invisible to a `warn`-level log entry with the HTTP status and body attached.

## Solution

The revoke call goes through Ruby's stdlib `Net::HTTP.post_form` directly. That single method enforces both the URL-encoded body and the `Content-Type: application/x-www-form-urlencoded` header — there's no way for a future maintainer to silently regress to JSON without seeing both pieces change. `token_type_hint: 'access_token'` is included in the body per RFC 7009 §2.1's recommendation.

Wire-level result:

```
POST /oauth/revoke HTTP/1.1
Host: app.convertkit.com
Content-Type: application/x-www-form-urlencoded
Content-Length: <n>

token=<access_token>&client_id=<id>&client_secret=<secret>&token_type_hint=access_token
```

Error semantics tighten. Non-2xx now raises `ConvertKit::OauthError` with `"Kit /oauth/revoke returned HTTP <code>: <body>"`. The only caller in production — Speckel's `ConvertKitService#revoke_token_for_provider` — already wraps in `rescue StandardError` and emits a `warn`-level structured log. Its behavior on a real failure changes from *silently logging success* to *logging a warn with HTTP status and body*. The success path is unchanged: `revoke_token` returns `true` and the caller logs `succeeded` as before.

`get_token` and `refresh_token` are untouched. They still use the gem's `Connection` class against `app.convertkit.com/oauth/token` — the connect flow works there today, and this PR doesn't disturb it.

## Design Decisions

| Decision | Context |
|---|---|
| Stay on `app.convertkit.com/oauth/revoke` rather than move to the canonical `api.kit.com/v4/oauth/revoke` | Kit's docs put all OAuth endpoints at `api.kit.com/v4/oauth/*`, but the gem and Speckel currently use `app.convertkit.com` for authorize and token. Moving revoke alone would split a single OAuth flow across two hosts. The Content-Type fix is what unblocks the actual bug; the host name is cosmetic in comparison. When Kit deprecates the legacy host, all three OAuth endpoints will migrate together in a coordinated change with proper end-to-end verification. |
| `Net::HTTP.post_form` directly, not a patched `Connection` | Stdlib enforces both the form encoding and the `Content-Type` header in a single call. Patching `Connection` to accept a per-request Content-Type override would add coupling for one caller's benefit, and stdlib here exactly mirrors the snippet Kit's engineer recommended — useful when a future Kit-side debugger reads our wire traffic. |
| Raise on non-2xx instead of returning a boolean | The previous `response.success?` return was the precise mechanism that hid this bug for over a year — an unparseable-request 200 looked identical to a real-revoke 200. Failures should be loud. The only caller already has `rescue StandardError` and structured-warn logging, so this immediately surfaces real failures in our existing log infrastructure with no caller-side change. |

## Blast Radius

Pure gem-internal change. Method signature is unchanged: `ConvertKit::OAuth.new(id, secret).revoke_token(token)` works exactly as before. The only production caller (`ConvertKitService#revoke_token_for_provider` in Speckel) already wraps the call in `rescue StandardError`, so failures land in existing log infrastructure with no caller-side change required.

What to watch after deploy:
- `mighty-logger` lines labelled `oauth,kit` with `message: "Kit /oauth/revoke failed"`. Pre-merge: never observed (the silent-200 path masked all real failures). Post-merge: any actual rejection from Kit (wrong client_id, expired credentials) becomes visible at `warn` level with the HTTP status and body attached.
- Successful revokes still look identical in our logs — the visible change is on Kit's side, not ours.

## Rollback Plan

Revert this PR via GitHub's Revert button. Returns to the silent-no-op state that's been running for over a year — a known steady state, not the state we want, but stable.

## Test plan

**Verifiable by agent before merging**

- [x] Full rspec suite under Ruby 2.7.7 (gem's `.ruby-version`): 140 examples, 0 failures, 99.51% coverage.
- [x] Full rspec suite under Ruby 3.4.7 (Speckel's Ruby): 140 examples, 2 failures. Both are pre-existing kwargs-strictness mock mismatches on `main` (`Purchases#create`, `Subscribers#bulk_create`); neither file is touched by this PR.
- [x] `oauth_spec.rb` itself: 16/16 pass on both Rubies.
- [x] Spec verifies the exact URL (`https://app.convertkit.com/oauth/revoke`), exact form parameters (`token`, `client_id`, `client_secret`, `token_type_hint=access_token`), `true` return on 2xx, and `ConvertKit::OauthError` raise with HTTP status and body on non-2xx.

**Cannot be verified before merge**

- [ ] Confirm Kit's server actually invalidates the token end-to-end — requires this gem to ship into Speckel, a live disconnect against a real Kit account, and Kit's engineer (or Kit's logs) confirming the revoke landed. Local mocks prove the request leaves the gem well-formed; only a round-trip proves Kit's side processes it.

